### PR TITLE
update decode-uri-component to 0.2.2

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -35,7 +35,7 @@
     "testEnvironment": "jsdom"
   },
   "dependencies": {
-    "decode-uri-component": "0.2.1",
+    "decode-uri-component": "0.2.2",
     "json-schema": "^0.4.0",
     "loader-utils": "^3.2.1",
     "minimatch": "3.0.5",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1300,13 +1300,10 @@ decimal.js@^10.2.1:
   version "10.3.1"
   resolved "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz"
 
-decode-uri-component@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.1.tgz"
-
-decode-uri-component@^0.2.0:
+decode-uri-component@0.2.2, decode-uri-component@^0.2.0:
   version "0.2.2"
-  resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 dedent@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
update decode-uri-component to 0.2.2 to fix cve - CVE-2022-38900 